### PR TITLE
zt/ignore attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,34 @@
 PATH
   remote: .
   specs:
-    ignorable (0.2.0)
+    ignorable (0.3.0)
       activerecord (>= 3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.0.0)
-      activesupport (= 4.0.0)
-      builder (~> 3.1.0)
-    activerecord (4.0.0)
-      activemodel (= 4.0.0)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.0)
-      arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.0)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+    activemodel (4.2.3)
+      activesupport (= 4.2.3)
+      builder (~> 3.1)
+    activerecord (4.2.3)
+      activemodel (= 4.2.3)
+      activesupport (= 4.2.3)
+      arel (~> 6.0)
+    activesupport (4.2.3)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     appraisal (0.5.2)
       bundler
       rake
-    arel (4.0.0)
-    atomic (1.1.12)
-    builder (3.1.4)
+    arel (6.0.3)
+    builder (3.2.2)
     diff-lcs (1.2.4)
-    i18n (0.6.4)
-    minitest (4.7.5)
-    multi_json (1.7.8)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.0)
     rake (10.1.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -42,9 +39,9 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.2)
     sqlite3 (1.3.7)
-    thread_safe (0.1.2)
-      atomic
-    tzinfo (0.3.37)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -55,3 +52,6 @@ DEPENDENCIES
   rake
   rspec (>= 2)
   sqlite3
+
+BUNDLED WITH
+   1.10.6

--- a/lib/ignorable.rb
+++ b/lib/ignorable.rb
@@ -3,6 +3,10 @@ require 'active_support/core_ext/class/attribute'
 
 module Ignorable
   module InstanceMethods
+    def attributes # :nodoc:
+      super.reject{|col, _val| self.class.ignored_column?(col)}
+    end
+
     def attribute_names # :nodoc:
       super.reject{|col| self.class.ignored_column?(col)}
     end

--- a/spec/ignorable_spec.rb
+++ b/spec/ignorable_spec.rb
@@ -67,6 +67,11 @@ describe Ignorable do
     end
   end
 
+  it "should remove the columns from the attributes hash" do
+    expect(TestModel.new.attributes.keys.sort).to eql ["id", "name"]
+    expect(Thing.new.attributes.keys.sort).to eql ["id", "test_model_id", "value"]
+  end
+
   it "should remove the columns from the attribute names" do
     expect(TestModel.new.attribute_names.sort).to eql ["id", "name"]
     expect(Thing.new.attribute_names.sort).to eql ["id", "test_model_id", "value"]


### PR DESCRIPTION
Rails 4.2 ActiveModel now loads the models attributes directly from the schema which includes the columns that are ignored using ignore_columns. This removes the ignored_columns from the attributes.
